### PR TITLE
Update tests so they don't fail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,3 @@ strict-rfc3339==0.7
 webcolors==1.8.1
 Sphinx==2.3.1
 sphinx-rtd-theme==0.4.3
-Werkzeug==1.0.1

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -70,12 +70,13 @@ def test_valid_duo_000004():
     assert valid
 
 
-def test_valid_duo_000005():
-    term = {"duo": [{"id": duo[5]}]}
-    ov = OntologyValidator(ont=ont, input_json=term)
-    valid, invalid = ov.validate_duo()
-    assert valid
-
+# def test_valid_duo_000005():
+#     term = {"duo": [{"id": duo[5]}]}
+#     ov = OntologyValidator(ont=ont, input_json=term)
+#     valid, invalid = ov.validate_duo()
+#     print(invalid)
+#     assert valid
+# 
 
 def test_valid_duo_000006():
     term = {"duo": [{"id": duo[6]}]}
@@ -105,11 +106,11 @@ def test_valid_duo_000012():
     assert valid
 
 
-def test_valid_duo_000014():
-    term = {"duo": [{"id": duo[14]}]}
-    ov = OntologyValidator(ont=ont, input_json=term)
-    valid, invalid = ov.validate_duo()
-    assert valid
+# def test_valid_duo_000014():
+#     term = {"duo": [{"id": duo[14]}]}
+#     ov = OntologyValidator(ont=ont, input_json=term)
+#     valid, invalid = ov.validate_duo()
+#     assert valid
 
 
 def test_valid_duo_000015():

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -445,7 +445,7 @@ def test_search_ontologies_duo(test_client):
     with context:
         response, code = operations.search_dataset_ontologies()
         assert code == 200
-        assert response == ["DUO:0000014", "DUO:0000018"]
+        assert response == ["DUO:0000012", "DUO:0000018"]
 
 def load_test_objects():
     dataset_1_id = uuid.uuid4().hex
@@ -459,7 +459,7 @@ def load_test_objects():
         'version': '0.1',
         'ontologies': [
             {"id": "duo",
-             "terms": [{"id": "DUO:0000018"}, {"id": "DUO:0000014"}]}
+             "terms": [{"id": "DUO:0000018"}, {"id": "DUO:0000012"}]}
         ]
 
 
@@ -473,7 +473,7 @@ def load_test_objects():
         'version': '0.3',
         'ontologies': [
             {"id": "duo",
-             "terms": [{"id": "DUO:0000014"}]}
+             "terms": [{"id": "DUO:0000012"}]}
         ]
 
     }

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -17,16 +17,8 @@ ontologies = {
   "d1": {
       "id": "duo",
       "terms": [
-        {'shorthand': 'NPU',
-         'name': 'not for profit use only',
-         'definition': 'This requirement indicates that use of the data is limited to not-for-profit organizations and not-for-profit use, non-commercial use.',
-         'id': 'DUO:0000018'},
-        {'shorthand': 'RU',
-         'name': 'research use only',
-
-         'definition': 'This data use limitation indicates that use is limited to research purposes (e.g., does not include its use in clinical care).',
-
-         'id': 'DUO:0000014'}
+        {'id': 'DUO:0000018', 'shorthand': 'NPUNCU', 'name': 'not for profit, non commercial use only', 'definition': 'This data use modifier indicates that use of the data is limited to not-for-profit organizations and not-for-profit use, non-commercial use.'}, 
+        {'id': 'DUO:0000012', 'shorthand': 'RS', 'name': 'research specific restrictions', 'definition': 'This data use modifier indicates that use is limited to studies of a certain research type.'}
       ]
   },
   "d2": {
@@ -44,4 +36,3 @@ ontologies = {
     ]
   }
 }
-


### PR DESCRIPTION
DUO actually removed two ontologies, duo:000005 and duo:0000014, which we were using for some tests in the test suite. I removed those references and updated the tests.